### PR TITLE
Fixes support for embedded languages

### DIFF
--- a/src/Tagger/RainbowTagger.cs
+++ b/src/Tagger/RainbowTagger.cs
@@ -20,9 +20,9 @@ namespace RainbowBraces
         private List<ITagSpan<IClassificationTag>> _tags = new();
         private bool _isEnabled;
 
-        public RainbowTagger(ITextView view, IClassificationTypeRegistryService registry, ITagAggregator<IClassificationTag> aggregator)
+        public RainbowTagger(ITextView view, ITextBuffer buffer, IClassificationTypeRegistryService registry, ITagAggregator<IClassificationTag> aggregator)
         {
-            _buffer = (ITextBuffer2)view.TextBuffer;
+            _buffer = (ITextBuffer2)buffer;
             _view = view;
             _registry = registry;
             _aggregator = aggregator;

--- a/src/Tagger/RainbowTaggerProvider.cs
+++ b/src/Tagger/RainbowTaggerProvider.cs
@@ -22,6 +22,10 @@ namespace RainbowBraces
         public bool _isProcessing { get; set; }
         public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag
         {
+            //We can ignore anything HTML, embedded languages will be handled separately
+            if (buffer.ContentType.IsOfType("HTML"))
+                return null;
+
             // Calling CreateTagAggregator creates a recursive situation, so _isProcessing ensures it only runs once per textview.
             if (!_isProcessing)
             {

--- a/src/Tagger/RainbowTaggerProvider.cs
+++ b/src/Tagger/RainbowTaggerProvider.cs
@@ -29,7 +29,7 @@ namespace RainbowBraces
                 ITagAggregator<IClassificationTag> aggregator = _aggregator.CreateTagAggregator<IClassificationTag>(textView);
                 _isProcessing = false;
 
-                return textView.Properties.GetOrCreateSingletonProperty(() => new RainbowTagger(textView, _registry, aggregator)) as ITagger<T>;
+                return buffer.Properties.GetOrCreateSingletonProperty(() => new RainbowTagger(textView, buffer, _registry, aggregator)) as ITagger<T>;
             }
 
             return null;


### PR DESCRIPTION
Hi Mads,

This fixes support for embbeded languages, including `cshtml` and `php` files. It worked until the changeset [664f608](https://github.com/madskristensen/RainbowBraces/commit/664f6088ca59f73c8219dccb3b16e91bceaaaa1d) 

Simple `cshtml` testcase:
```cshtml
@{
    {
        {
            {
            }
        }
    }
}
```

Thank you