### PR TITLE
Enable Phalanger content type

### DIFF
--- a/src/Tagger/RainbowTaggerProvider.cs
+++ b/src/Tagger/RainbowTaggerProvider.cs
@@ -19,6 +19,7 @@ namespace RainbowBraces
     [ContentType("SQL")]
     [ContentType("SQL Server Tools")]
     [ContentType("php")]
+    [ContentType("phalanger")]
     [ContentType("Code++")]
     [TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
     [TagType(typeof(IClassificationTag))]


### PR DESCRIPTION
For historical reasons, PHP Tools used Phalanger content type instead of PHP. We will change it, but we can leave it here so older versions of PHP Tools work too.