### PR TITLE
Add customizable cycle length

### DIFF
--- a/src/Options/General.cs
+++ b/src/Options/General.cs
@@ -25,6 +25,12 @@ namespace RainbowBraces
         [Browsable(false)]
         public int Timeout { get; set; } = 400;
 
+        [Category("General")]
+        [DisplayName("Cycle length")]
+        [Description("Coloring will repeat after this many nested braces.")]
+        [DefaultValue(4)]
+        public int CycleLength { get; set; } = 4;
+
         [Category("Braces and brackets")]
         [DisplayName("Colorize curly brackets { }")]
         [Description("Determines whether or not curly brackets should be colorized.")]

--- a/src/Tagger/ClassificationTypes.cs
+++ b/src/Tagger/ClassificationTypes.cs
@@ -7,15 +7,13 @@ namespace RainbowBraces
 {
     public class ClassificationTypes
     {
-        private const int _maxLevels = 4;
-
-        public static string GetName(int level)
+        public static string GetName(int level, int cycleLength)
         {
-            int mod = level % _maxLevels;
+            int mod = level % cycleLength;
 
             if (mod == 0)
             {
-                mod = _maxLevels;
+                mod = cycleLength;
             }
 
             return mod switch
@@ -23,14 +21,24 @@ namespace RainbowBraces
                 1 => Level1,
                 2 => Level2,
                 3 => Level3,
-                _ => Level4
+                4 => Level4,
+                5 => Level5,
+                6 => Level6,
+                7 => Level7,
+                8 => Level8,
+                _ => Level9,
             };
         }
 
-    public const string Level1 = "Rainbow Brace level 1";
+        public const string Level1 = "Rainbow Brace level 1";
         public const string Level2 = "Rainbow Brace level 2";
         public const string Level3 = "Rainbow Brace level 3";
         public const string Level4 = "Rainbow Brace level 4";
+        public const string Level5 = "Rainbow Brace level 5";
+        public const string Level6 = "Rainbow Brace level 6";
+        public const string Level7 = "Rainbow Brace level 7";
+        public const string Level8 = "Rainbow Brace level 8";
+        public const string Level9 = "Rainbow Brace level 9";
 
         [Export, Name(Level1)]
         internal static ClassificationTypeDefinition Level1Classification = null;
@@ -43,6 +51,21 @@ namespace RainbowBraces
 
         [Export, Name(Level4)]
         internal static ClassificationTypeDefinition Level4Classification = null;
+
+        [Export, Name(Level5)]
+        internal static ClassificationTypeDefinition Level5Classification = null;
+
+        [Export, Name(Level6)]
+        internal static ClassificationTypeDefinition Level6Classification = null;
+
+        [Export, Name(Level7)]
+        internal static ClassificationTypeDefinition Level7Classification = null;
+
+        [Export, Name(Level8)]
+        internal static ClassificationTypeDefinition Level8Classification = null;
+
+        [Export, Name(Level9)]
+        internal static ClassificationTypeDefinition Level9Classification = null;
     }
 
     [Export(typeof(EditorFormatDefinition))]
@@ -98,6 +121,76 @@ namespace RainbowBraces
         {
             ForegroundColor = Colors.OliveDrab;
             DisplayName = ClassificationTypes.Level4;
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.Level5)]
+    [Name(ClassificationTypes.Level5)]
+    [UserVisible(true)]
+    [Order(After = Priority.High)]
+    internal sealed class Level5 : ClassificationFormatDefinition
+    {
+        public Level5()
+        {
+            ForegroundColor = Colors.OliveDrab;
+            DisplayName = ClassificationTypes.Level5;
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.Level6)]
+    [Name(ClassificationTypes.Level6)]
+    [UserVisible(true)]
+    [Order(After = Priority.High)]
+    internal sealed class Level6 : ClassificationFormatDefinition
+    {
+        public Level6()
+        {
+            ForegroundColor = Colors.OliveDrab;
+            DisplayName = ClassificationTypes.Level6;
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.Level7)]
+    [Name(ClassificationTypes.Level7)]
+    [UserVisible(true)]
+    [Order(After = Priority.High)]
+    internal sealed class Level7 : ClassificationFormatDefinition
+    {
+        public Level7()
+        {
+            ForegroundColor = Colors.OliveDrab;
+            DisplayName = ClassificationTypes.Level7;
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.Level8)]
+    [Name(ClassificationTypes.Level8)]
+    [UserVisible(true)]
+    [Order(After = Priority.High)]
+    internal sealed class Level8 : ClassificationFormatDefinition
+    {
+        public Level8()
+        {
+            ForegroundColor = Colors.OliveDrab;
+            DisplayName = ClassificationTypes.Level8;
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.Level9)]
+    [Name(ClassificationTypes.Level9)]
+    [UserVisible(true)]
+    [Order(After = Priority.High)]
+    internal sealed class Level9 : ClassificationFormatDefinition
+    {
+        public Level9()
+        {
+            ForegroundColor = Colors.OliveDrab;
+            DisplayName = ClassificationTypes.Level9;
         }
     }
 }

--- a/src/Tagger/RainbowTagger.cs
+++ b/src/Tagger/RainbowTagger.cs
@@ -193,7 +193,7 @@ namespace RainbowBraces
             }
 
             _braces = pairs;
-            _tags = GenerateTagSpans(pairs);
+            _tags = GenerateTagSpans(pairs, options.CycleLength);
             TagsChanged?.Invoke(this, new(new(_buffer.CurrentSnapshot, visibleStart, visibleEnd - visibleStart)));
         }
 
@@ -206,13 +206,13 @@ namespace RainbowBraces
             }
         }
 
-        private List<ITagSpan<IClassificationTag>> GenerateTagSpans(IEnumerable<BracePair> pairs)
+        private List<ITagSpan<IClassificationTag>> GenerateTagSpans(IEnumerable<BracePair> pairs, int cycleLength)
         {
             List<ITagSpan<IClassificationTag>> tags = new();
 
             foreach (BracePair pair in pairs)
             {
-                IClassificationType classification = _registry.GetClassificationType(ClassificationTypes.GetName(pair.Level));
+                IClassificationType classification = _registry.GetClassificationType(ClassificationTypes.GetName(pair.Level, cycleLength));
                 ClassificationTag openTag = new(classification);
                 SnapshotSpan openSpan = new(_buffer.CurrentSnapshot, pair.Open);
                 tags.Add(new TagSpan<IClassificationTag>(openSpan, openTag));


### PR DESCRIPTION
Creates color options for up to nine nesting levels and adds a setting letting the user to choose how many of those colors will be used. This allows for a lot more customization, and fixes #11.

I'm unsure of the setting name -- for now I went with _Cycle length_, but that might be a bit abstract. Perhaps something like _Color wheel size_ might be better?

I went with nine levels instead of ten because `10` is ordered between `1` and `2` in the Fonts and Colors list 😄. I don't think the ordering can be defined on an item level? In any case, if having ten levels is more important than the ordering, I can easily add another level of course.

Todo:

- [ ] Find colors for the new levels.