### PR TITLE
Don't count empty spans in braces cache

### DIFF
--- a/src/Tagger/RainbowTagger.cs
+++ b/src/Tagger/RainbowTagger.cs
@@ -137,11 +137,19 @@ namespace RainbowBraces
             if (changedLine.LineNumber > 0)
             {
                 // Use the cache for all brackets defined above the position of the change
-                pairs.AddRange(_braces.Where(p => p.Open.End <= visibleStart || p.Close.End <= visibleStart));
+                pairs.AddRange(_braces.Where(IsAboveChange));
 
                 foreach (BracePair pair in pairs)
                 {
                     pair.Close = pair.Close.End >= visibleStart ? _empty : pair.Close;
+                }
+
+                bool IsAboveChange(BracePair p)
+                {
+                    // empty spans can be ignored especially the [0..0) that would be always above change
+                    if (!p.Open.IsEmpty && p.Open.End <= visibleStart) return true;
+                    if (!p.Close.IsEmpty && p.Close.End <= visibleStart) return true;
+                    return false;
                 }
             }
 


### PR DESCRIPTION
I did some debuging and found bug in caching "unchanged" braces. When one end (open/close) of pair was not known, it had default value at position 0, lentgh 0 which was always above first changed line and so got into cache. But if correct brace position changed there were 2 colored characters for 1 brace. After another change 3 etc. After some typing (especially in comments when syntax elements were not updated) the colors got really messy.

It could fixes these issues: #28 #29 #39 #40