### PR TITLE
Feature: Support for angle brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ or get the [CI build][vsixgallery].
 
 ----------------------------------------
 
-Colorizes matching brace pairs to make it easy to identify them and their scope. Works for curly brackets, parentheses, and square brackets. Inspired by the [Bracket pair colorization](https://developercommunity.visualstudio.com/t/Bracket-pair-colorization/1631048?space=8&ftype=idea&q=brackets) feature request for Visual Studio (please go vote for it).
+Colorizes matching brace pairs to make it easy to identify them and their scope. Works for curly brackets, parentheses, square brackets and angle brackets. Inspired by the [Bracket pair colorization](https://developercommunity.visualstudio.com/t/Bracket-pair-colorization/1631048?space=8&ftype=idea&q=brackets) feature request for Visual Studio (please go vote for it).
 
 ![Screenshot](art/screenshot.png)
 

--- a/src/Options/General.cs
+++ b/src/Options/General.cs
@@ -48,6 +48,12 @@ namespace RainbowBraces
         [Description("Determines whether or not square brackets should be colorized.")]
         [DefaultValue(true)]
         public bool SquareBrackets { get; set; } = true;
+        
+        [Category("Braces and brackets")]
+        [DisplayName("Colorize angle brackets < >")]
+        [Description("Determines whether or not angle brackets should be colorized.")]
+        [DefaultValue(true)]
+        public bool AngleBrackets { get; set; } = true;
 
         [Category("Braces and brackets")]
         [DisplayName("(Experimental) Colorize vertical lines between { }")]

--- a/src/Tagger/BracePairBuilderCollection.cs
+++ b/src/Tagger/BracePairBuilderCollection.cs
@@ -10,9 +10,9 @@ namespace RainbowBraces
         
         public int Level => _builders.Sum(builder => builder.OpenPairs.Count);
 
-        public void AddBuilder(char open, char close)
+        public void AddBuilder(char open, char close, TagAllowance[] allowedTags = null)
         {
-            BracePairBuilder builder = new(open, close, this);
+            BracePairBuilder builder = new(open, close, this, allowedTags);
             _builders.Add(builder);
         }
 


### PR DESCRIPTION
Visual Studio 17.6 Preview 1 has natively colorized braces but also angle brackets and it looks weird to have everything else colorized by this extension but angle brackets by Visual Studio.

I'm not sure if this feature should be opt in or opt out.

I've updated parse logic a little to handle this and prepare for later use in .razor/.cshtml supprt where simple allow/disallow don't work. Braces belongs there to up to 3 different tags including general HTML attribute tag.