### PR TITLE
Feature: Support for XML/HTML

### DIFF
--- a/src/Options/General.cs
+++ b/src/Options/General.cs
@@ -61,6 +61,12 @@ namespace RainbowBraces
         [DefaultValue(false)]
         public bool VerticalAdornments { get; set; } = false;
 
+        [Category("Braces and brackets")]
+        [DisplayName("Colorize XML/XHTML tags <item> ... </item>")]
+        [Description("Determines whether or not XML or XHTML tags should be colored to clarify nestiness.")]
+        [DefaultValue(true)]
+        public bool XmlTags { get; set; } = true;
+
         // Used for the rating prompt
         [Browsable(false)]
         public int RatingRequests { get; set; }

--- a/src/RainbowBraces.csproj
+++ b/src/RainbowBraces.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Tagger\CssAllowanceResolver.cs" />
     <Compile Include="Tagger\DefaultAllowanceResolver.cs" />
     <Compile Include="Tagger\MsBuildAllowanceResolver.cs" />
+    <Compile Include="Tagger\PairBuilder.cs" />
     <Compile Include="Tagger\RainbowTagger.cs" />
     <Compile Include="Tagger\RainbowTaggerProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -77,6 +78,8 @@
     <Compile Include="Tagger\RazorAllowanceResolver.cs" />
     <Compile Include="Tagger\TagAllowance.cs" />
     <Compile Include="Tagger\VerticalAdornmentsColorizer.cs" />
+    <Compile Include="Tagger\XmlAllowanceResolver.cs" />
+    <Compile Include="Tagger\XmlTagPairBuilder.cs" />
     <Compile Include="VSCommandTable.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Tagger/AllowanceResolver.cs
+++ b/src/Tagger/AllowanceResolver.cs
@@ -44,6 +44,20 @@ namespace RainbowBraces.Tagger
         /// </summary>
         public virtual bool CanChangeTags => false;
 
+        /// <summary>
+        /// If this property is <see langword="true"/> resolver can return <see cref="TagAllowance.XmlTag"/>.
+        /// This property is for performance optimization.
+        /// </summary>
+        public virtual bool AllowXmlTags => false;
+
+        /// <summary>
+        /// If this property is <see langword="true"/> resolver will treat HTML void elements as self-closed 
+        /// and <see cref="AllowXmlTags"/> is also expected to return <see langword="true"/>.
+        /// Otherwise HTML void element are treated as malformed XML document.
+        /// https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+        /// </summary>
+        public virtual bool AllowHtmlVoidElement => false;
+
         private TagAllowance GetAllowance(IClassificationType tagType)
         {
             if (tagType is ILayeredClassificationType layeredType) return IsAllowed(layeredType);

--- a/src/Tagger/BracePair.cs
+++ b/src/Tagger/BracePair.cs
@@ -8,4 +8,6 @@ namespace RainbowBraces
         public Span Close { get; set; }
         public int Level { get; set; }
     }
+
+    public class DummyBracePair : BracePair { }
 }

--- a/src/Tagger/BracePairBuilderCollection.cs
+++ b/src/Tagger/BracePairBuilderCollection.cs
@@ -4,9 +4,9 @@ using System.Linq;
 
 namespace RainbowBraces
 {
-    public class BracePairBuilderCollection : IEnumerable<BracePairBuilder>
+    public class BracePairBuilderCollection : IEnumerable<PairBuilder>
     {
-        private readonly List<BracePairBuilder> _builders = new();
+        private readonly List<PairBuilder> _builders = new();
         
         public int Level => _builders.Sum(builder => builder.OpenPairs.Count);
 
@@ -16,11 +16,17 @@ namespace RainbowBraces
             _builders.Add(builder);
         }
 
+        public void AddXmlTagBuilder(bool allowHtmlVoidTag)
+        {
+            XmlTagPairBuilder builder = new(this, allowHtmlVoidTag);
+            _builders.Add(builder);
+        }
+
         public void LoadFromCache(BracePairCache cache, int changeStart)
         {
-            foreach (BracePairBuilder builder in _builders)
+            foreach (PairBuilder builder in _builders)
             {
-                if (cache.TryGet(builder.Open, builder.Close, out List<BracePair> pairs))
+                if (cache.TryGet(builder, out List<BracePair> pairs))
                 {
                     builder.LoadFromCache(pairs, changeStart);
                 }
@@ -29,14 +35,14 @@ namespace RainbowBraces
 
         public void SaveToCache(BracePairCache cache)
         {
-            foreach (BracePairBuilder builder in _builders)
+            foreach (PairBuilder builder in _builders)
             {
-                cache.Set(builder.Open, builder.Close, builder.Pairs);
+                cache.Set(builder, builder.Pairs);
             }
         }
 
         /// <inheritdoc />
-        public IEnumerator<BracePairBuilder> GetEnumerator() => _builders.GetEnumerator();
+        public IEnumerator<PairBuilder> GetEnumerator() => _builders.GetEnumerator();
 
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Tagger/BracePairCache.cs
+++ b/src/Tagger/BracePairCache.cs
@@ -4,11 +4,11 @@ namespace RainbowBraces
 {
     public class BracePairCache
     {
-        private readonly Dictionary<(char Open, char Close), List<BracePair>> _cachedPairs = new();
+        private readonly Dictionary<object, List<BracePair>> _cachedPairs = new();
         
-        public bool TryGet(char open, char close, out List<BracePair> cache) => _cachedPairs.TryGetValue((open, close), out cache);
+        public bool TryGet(PairBuilder builder, out List<BracePair> cache) => _cachedPairs.TryGetValue(builder.GetCacheKey(), out cache);
 
-        public void Set(char open, char close, List<BracePair> cache) => _cachedPairs[(open, close)] = cache;
+        public void Set(PairBuilder builder, List<BracePair> cache) => _cachedPairs[builder.GetCacheKey()] = cache;
 
         public void Clear() => _cachedPairs.Clear();
     }

--- a/src/Tagger/DefaultAllowanceResolver.cs
+++ b/src/Tagger/DefaultAllowanceResolver.cs
@@ -5,6 +5,7 @@ namespace RainbowBraces.Tagger
 {
     public class DefaultAllowanceResolver : AllowanceResolver
     {
+        /// <inheritdoc />
         protected override TagAllowance IsAllowed(IClassificationType tagType)
         {
             // Allow tags for braces
@@ -15,6 +16,7 @@ namespace RainbowBraces.Tagger
             return TagAllowance.Disallowed;
         }
 
+        /// <inheritdoc />
         protected override TagAllowance IsAllowed(ILayeredClassificationType layeredType)
         {
             string classification = layeredType.Classification;

--- a/src/Tagger/MsBuildAllowanceResolver.cs
+++ b/src/Tagger/MsBuildAllowanceResolver.cs
@@ -4,6 +4,9 @@ namespace RainbowBraces.Tagger
 {
     public class MsBuildAllowanceResolver : DefaultAllowanceResolver
     {
+        /// <inheritdoc />
+        public override bool AllowXmlTags => true;
+
         protected override TagAllowance IsAllowed(IClassificationType tagType)
         {
             // Allow for conditions in attributes or other transformations
@@ -11,6 +14,10 @@ namespace RainbowBraces.Tagger
 
             // Allow for property transformations as values
             if (tagType.IsOfType("XML Text")) return TagAllowance.Allowed;
+
+            // Allow <,</,>,/> XML delimiters
+            if (General.Instance.XmlTags && tagType.IsOfType("XML Delimiter")) return TagAllowance.XmlTag;
+
             return TagAllowance.Disallowed;
         }
 
@@ -23,6 +30,10 @@ namespace RainbowBraces.Tagger
 
             // Allow for property transformations as values
             if (classification == "XML Text") return TagAllowance.Allowed;
+
+            // Allow <,</,>,/> XML delimiters
+            if (General.Instance.XmlTags && classification == "XML Delimiter") return TagAllowance.XmlTag;
+
             return TagAllowance.Disallowed;
         }
     }

--- a/src/Tagger/PairBuilder.cs
+++ b/src/Tagger/PairBuilder.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+
+namespace RainbowBraces
+{
+    public abstract class PairBuilder
+    {
+        private readonly BracePairBuilderCollection _collection;
+
+        protected PairBuilder(BracePairBuilderCollection collection)
+        {
+            _collection = collection;
+        }
+
+        public List<BracePair> Pairs { get; } = new();
+
+        public Stack<BracePair> OpenPairs { get; } = new();
+
+        // Use global level for all brace types
+        protected int NextLevel => _collection.Level + 1;
+
+        protected static Span Empty { get; } = new(0, 0);
+
+        public void LoadFromCache(IList<BracePair> pairs, int changeStart)
+        {
+            // Use the cache for all brackets defined above the position of the change
+            Pairs.AddRange(pairs.Where(IsAboveChange));
+
+            // Discard all cached closing braces after first change because it could not match anymore
+            // We are ordering them by level so we can add them to OpenPairs stack in correct order for future processing
+            foreach (BracePair openPair in Pairs
+                         .Where(pair => pair.Close.End >= changeStart || pair.Close == Empty)
+                         .OrderBy(pair => pair.Level))
+            {
+                openPair.Close = Empty;
+                OpenPairs.Push(openPair);
+            }
+
+            bool IsAboveChange(BracePair p)
+            {
+                // Dummy span is expected to be empty
+                if (p is DummyBracePair)
+                {
+                    if (p.Open.End <= changeStart) return true;
+                    if (p.Close.End <= changeStart) return true;
+                    return false;
+                }
+
+                // Empty spans can be ignored especially the [0..0) that would be always above change
+                if (!p.Open.IsEmpty && p.Open.End <= changeStart) return true;
+                if (!p.Close.IsEmpty && p.Close.End <= changeStart) return true;
+                return false;
+            }
+        }
+
+        public abstract bool TryAdd(string match, Span braceSpan, IReadOnlyList<(Span Span, TagAllowance Allowance)> matchingSpans, (string Line, int Offset) line);
+
+        public virtual object GetCacheKey() => GetType();
+
+        public virtual IEnumerable<BracePair> GetPairs() => Pairs;
+    }
+}

--- a/src/Tagger/RainbowTaggerProvider.cs
+++ b/src/Tagger/RainbowTaggerProvider.cs
@@ -18,6 +18,7 @@ namespace RainbowBraces
     [ContentType(ContentTypes.Json)]
     [ContentType(ContentTypes.Xaml)]
     [ContentType(ContentTypes.Xml)]
+    [ContentType(ContentTypes.WebForms)]
     [ContentType("TypeScript")]
     [ContentType("SQL")]
     [ContentType("SQL Server Tools")]
@@ -44,7 +45,7 @@ namespace RainbowBraces
         public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag
         {
             // Calling CreateTagAggregator creates a recursive situation, so _isProcessing ensures it only runs once per textview.
-            if (textView.TextBuffer != buffer || _isProcessing)
+            if (!IsSupportedBuffer(textView, buffer) || _isProcessing)
             {
                 return null;
             }
@@ -65,6 +66,15 @@ namespace RainbowBraces
             {
                 _isProcessing = false;
             }
+        }
+
+        private static bool IsSupportedBuffer(ITextView textView, ITextBuffer buffer)
+        {
+            if (textView.TextBuffer == buffer) return true;
+
+            // HTML textview don't use HTML buffer but only HTMLProjection.
+            if (buffer.ContentType.IsOfType("HTML") && textView.TextBuffer.ContentType.IsOfType("HTMLProjection")) return true;
+            return false;
         }
     }
 }

--- a/src/Tagger/RazorAllowanceResolver.cs
+++ b/src/Tagger/RazorAllowanceResolver.cs
@@ -1,4 +1,6 @@
-﻿namespace RainbowBraces.Tagger;
+﻿using Microsoft.VisualStudio.Text.Classification;
+
+namespace RainbowBraces.Tagger;
 
 public class RazorAllowanceResolver : DefaultAllowanceResolver
 {
@@ -12,5 +14,27 @@ public class RazorAllowanceResolver : DefaultAllowanceResolver
     /// <remarks>
     /// Tags are changed multiple times in razor templates, we need to listen to these changes.
     /// </remarks>
-    public override bool CanChangeTags => true; 
+    public override bool CanChangeTags => true;
+
+    /// <inheritdoc />
+    public override bool AllowXmlTags => true;
+
+    /// <inheritdoc />
+    public override bool AllowHtmlVoidElement => true;
+
+    /// <inheritdoc />
+    protected override TagAllowance IsAllowed(IClassificationType tagType)
+    {
+        if (General.Instance.XmlTags && tagType.IsOfType("HTML Tag Delimiter")) return TagAllowance.XmlTag;
+
+        return base.IsAllowed(tagType);
+    }
+
+    /// <inheritdoc />
+    protected override TagAllowance IsAllowed(ILayeredClassificationType layeredType)
+    {
+        if (General.Instance.XmlTags && layeredType.Classification is "HTML Tag Delimiter") return TagAllowance.XmlTag;
+
+        return base.IsAllowed(layeredType);
+    }
 }

--- a/src/Tagger/TagAllowance.cs
+++ b/src/Tagger/TagAllowance.cs
@@ -7,6 +7,7 @@
         Punctuation,
         Operator,
         Delimiter,
-        Debug
+        Debug,
+        XmlTag
     }
 }

--- a/src/Tagger/XmlAllowanceResolver.cs
+++ b/src/Tagger/XmlAllowanceResolver.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.VisualStudio.Text.Classification;
+
+namespace RainbowBraces.Tagger
+{
+    public class XmlAllowanceResolver : DefaultAllowanceResolver
+    {
+        private readonly string _allowedDelimiter;
+
+        public XmlAllowanceResolver(string allowedDelimiter, bool allowHtmlVoidElement = false)
+        {
+            _allowedDelimiter = allowedDelimiter;
+            AllowHtmlVoidElement = allowHtmlVoidElement;
+        }
+
+        /// <inheritdoc />
+        public override bool AllowXmlTags => true;
+
+        /// <inheritdoc />
+        public override bool AllowHtmlVoidElement { get; }
+
+        /// <inheritdoc />
+        protected override TagAllowance IsAllowed(IClassificationType tagType)
+        {
+            if (General.Instance.XmlTags)
+            {
+                // Allow <,</,>,/> XML delimiters
+                if (tagType.IsOfType(_allowedDelimiter)) return TagAllowance.XmlTag;
+            }
+
+            return base.IsAllowed(tagType);
+        }
+
+        /// <inheritdoc />
+        protected override TagAllowance IsAllowed(ILayeredClassificationType layeredType)
+        {
+            string classification = layeredType.Classification;
+
+            if (General.Instance.XmlTags)
+            {
+                // Allow <,</,>,/> XML delimiters
+                if (classification == _allowedDelimiter) return TagAllowance.XmlTag;
+            }
+
+            return base.IsAllowed(layeredType);
+        }
+    }
+}

--- a/src/Tagger/XmlTagPairBuilder.cs
+++ b/src/Tagger/XmlTagPairBuilder.cs
@@ -1,0 +1,197 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Text;
+
+namespace RainbowBraces
+{
+    public class XmlTagPairBuilder : PairBuilder
+    {
+        private readonly bool _allowHtmlVoidTag;
+        private bool _inCloseTag;
+        private bool _inVoidTag;
+
+        /// <inheritdoc />
+        public XmlTagPairBuilder(BracePairBuilderCollection collection, bool allowHtmlVoidTag) : base(collection)
+        {
+            _allowHtmlVoidTag = allowHtmlVoidTag;
+        }
+
+        /// <inheritdoc />
+        public override bool TryAdd(string match, Span braceSpan, IReadOnlyList<(Span Span, TagAllowance Allowance)> matchingSpans, (string Line, int Offset) line)
+        {
+            if (matchingSpans.Count == 0) return false;
+            bool isOpenBracket = match is "<" or "</";
+            bool isCloseBracket = match is ">" or "/>";
+            foreach ((Span Span, TagAllowance Allowance) matchingSpan in matchingSpans)
+            {
+                // Only XML tags are allowed to intersect
+                if (matchingSpan.Allowance != TagAllowance.XmlTag) return false;
+                if (matchingSpan.Span.Length <= match.Length) continue;
+
+                // XML tagger is using tags that can span up to 2 brackets (1 close and 1 open) and whitespaces around them.
+                int spanStart = matchingSpan.Span.Start;
+                int spanEnd = matchingSpan.Span.End;
+
+                // Trim whitespaces from start.
+                for (; spanStart < spanEnd; spanStart++)
+                {
+                    if (!char.IsWhiteSpace(GetChar(line, spanStart))) break;
+                }
+
+                // Trim whitespaces from end.
+                for (; spanEnd > spanStart; spanEnd--)
+                {
+                    if (!char.IsWhiteSpace(GetChar(line, spanEnd - 1))) break;
+                }
+
+                if (isOpenBracket && spanStart != braceSpan.Start)
+                {
+                    // If is open bracket then in matching span can be previous close bracket.
+                    if (IsLineText(line, spanStart, "/>")) spanStart += 2;
+                    else if (IsLineText(line, spanStart, ">")) spanStart++;
+                    
+                    // If so, again trim whitespaces from start.
+                    for (; spanStart < spanEnd; spanStart++)
+                    {
+                        if (!char.IsWhiteSpace(GetChar(line, spanStart))) break;
+                    }
+                }
+
+                if (isCloseBracket && spanEnd != braceSpan.End)
+                {
+                    // If is close bracket in matching span can be next open bracket.
+                    if (IsLineText(line, spanEnd - 2, "</")) spanEnd -= 2;
+                    else if (IsLineText(line, spanEnd - 1, "<")) spanEnd--;
+                    
+                    // If so, again trim whitespaces from end.
+                    for (; spanEnd > spanStart; spanEnd--)
+                    {
+                        if (!char.IsWhiteSpace(GetChar(line, spanEnd - 1))) break;
+                    }
+                }
+
+                // If trimmed matching span still not exactly match bracket span the tag is not allowed (eg. is comment or preprocessor).
+                if (spanEnd != braceSpan.End) return false;
+                if (spanStart != braceSpan.Start) return false;
+            }
+
+            if (isOpenBracket)
+            {
+                if (match is "</")
+                {
+                    // If is open bracket of closing tag close the dummy pair for XML element content.
+                    if (OpenPairs.Count != 0)
+                    {
+                        BracePair dummy = OpenPairs.Pop();
+                        dummy.Close = new Span(braceSpan.Start, 0);
+                    }
+
+                    // Mark the tag as closing.
+                    _inCloseTag = true;
+                }
+                else if (_allowHtmlVoidTag)
+                {
+                    // If current tag is of HTML void element we'll mark it as it will be self-closing one.
+                    _inVoidTag = IsHtmlVoidTag(braceSpan, line);
+                }
+
+                // Create new bracket pair for tag.
+                BracePair pair = new()
+                {
+                    Level = NextLevel,
+                    Open = braceSpan
+                };
+                Pairs.Add(pair);
+                OpenPairs.Push(pair);
+            }
+            else if (isCloseBracket)
+            {
+                // Closing bracket before opening, document is malformed.
+                if (OpenPairs.Count == 0)
+                {
+                    // Set default color, could be some error color specified.
+                    Pairs.Add(new BracePair()
+                    {
+                        Level = 1,
+                        Close = braceSpan
+                    });
+                }
+                else
+                {
+                    BracePair pair = OpenPairs.Pop();
+                    pair.Close = braceSpan;
+                }
+
+                // If the tag is not of self-closing element or HTML void element we'll emit dummy pair for XML element content.
+                if (match is ">" && !_inCloseTag && !_inVoidTag)
+                {
+                    DummyBracePair dummy = new() { Level = NextLevel, Open = new Span(braceSpan.End, 0) };
+                    OpenPairs.Push(dummy);
+                    Pairs.Add(dummy);
+                }
+
+                // Reset intag flags.
+                _inCloseTag = false;
+                _inVoidTag = false;
+            }
+            else
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Will return only pairs for tag brackets without dummy.
+        /// </remarks>
+        public override IEnumerable<BracePair> GetPairs() => Pairs.Where(p => p is not DummyBracePair);
+
+        private static bool IsHtmlVoidTag(Span braceSpan, (string Line, int Offset) line)
+        {
+            // List of HTML void elements - https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+            if (IsTag("area")) return true;
+            if (IsTag("base")) return true;
+            if (IsTag("br")) return true;
+            if (IsTag("col")) return true;
+            if (IsTag("embed")) return true;
+            if (IsTag("hr")) return true;
+            if (IsTag("img")) return true;
+            if (IsTag("input")) return true;
+            if (IsTag("keygen")) return true;
+            if (IsTag("link")) return true;
+            if (IsTag("meta")) return true;
+            if (IsTag("param")) return true;
+            if (IsTag("source")) return true;
+            if (IsTag("track")) return true;
+            if (IsTag("wbr")) return true;
+
+            return false;
+
+            bool IsTag(string tag)
+            {
+                return IsLineText(line, braceSpan.End, tag, true);
+            }
+        }
+
+        private static bool IsLineText((string Line, int Offset) line, int absoluteOffset, string text, bool toLower = false)
+        {
+            for (int i = 0; i < text.Length; i++)
+            {
+                char c = GetChar(line, absoluteOffset + i);
+                if (toLower) c = char.ToLower(c);
+                if (c != text[i]) return false;
+            }
+
+            return true;
+        }
+
+        private static char GetChar((string Line, int Offset) line, int absoluteOffset)
+        {
+            int index = absoluteOffset - line.Offset;
+            if (index < 0 || index >= line.Line.Length) return '\0';
+            return line.Line[index];
+        }
+    }
+
+}


### PR DESCRIPTION
This adds support for XML and HTML files (also HTML in .razor). The pull request is big. I needed to do more changes in infrastructure to support it.
I choosed to make it opt-out but can be made opt-in. It is more complex than simple single char braces ()[]{}<>.

![image](https://github.com/madskristensen/RainbowBraces/assets/17590847/fc3184e8-d4b6-4062-9ac5-423adf40eb6d)
![image](https://github.com/madskristensen/RainbowBraces/assets/17590847/0626107c-acbb-46ed-a56d-eb270aec867a)

I plan to do some follow-ups (more supported XML-like content types, update docs, split classes to namespaces..) and probably fixes.