### PR TITLE
Experimental feature: Fix some bugs in C++ templates + some enhancements to core

### DIFF
--- a/src/RainbowBraces.csproj
+++ b/src/RainbowBraces.csproj
@@ -57,9 +57,11 @@
     <Compile Include="Helper\Debouncer.cs" />
     <Compile Include="Options\General.cs" />
     <Compile Include="Tagger\CPlusPlusAllowanceResolver.cs" />
+    <Compile Include="Tagger\CPlusPlusTemplateTagPairBuilder.cs" />
     <Compile Include="Tagger\CssAllowanceResolver.cs" />
     <Compile Include="Tagger\DefaultAllowanceResolver.cs" />
     <Compile Include="Tagger\JavascriptAllowanceResolver.cs" />
+    <Compile Include="Tagger\MatchingContext.cs" />
     <Compile Include="Tagger\MsBuildAllowanceResolver.cs" />
     <Compile Include="Tagger\PairBuilder.cs" />
     <Compile Include="Tagger\RainbowTagger.cs" />

--- a/src/Tagger/AllowanceResolver.cs
+++ b/src/Tagger/AllowanceResolver.cs
@@ -35,6 +35,38 @@ namespace RainbowBraces.Tagger
         }
 
         /// <summary>
+        /// Creates builder collection specific for current resolver with respect to <paramref name="options"/>.
+        /// </summary>
+        public virtual BracePairBuilderCollection CreateBuilders(General options)
+        {
+            // Create builders for each brace type
+            BracePairBuilderCollection builders = new();
+            if (options.Parentheses) builders.AddBuilder('(', ')');
+            if (options.CurlyBrackets) builders.AddBuilder('{', '}');
+            if (options.SquareBrackets) builders.AddBuilder('[', ']');
+            if (options.AngleBrackets) builders.AddBuilder('<', '>', new[] { TagAllowance.Punctuation }); // Allow only punctuation
+            if (options.XmlTags && AllowXmlTags) builders.AddXmlTagBuilder(AllowHtmlVoidElement);
+
+            return builders;
+        }
+
+        /// <summary>
+        /// Method invoked before processing tags. Can be used to initialize resources,
+        /// </summary>
+        public virtual void Prepare()
+        {
+
+        }
+
+        /// <summary>
+        /// Method invoked after processed tags. Can be used to cleanup resources.
+        /// </summary>
+        public virtual void Cleanup()
+        {
+
+        }
+
+        /// <summary>
         /// If this property is <see langword="true"/> brace should be considered pair if is not in another tag.
         /// Otherwise brace will be treated as unrelated text.
         /// </summary>

--- a/src/Tagger/BracePairBuilder.cs
+++ b/src/Tagger/BracePairBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
+using RainbowBraces.Tagger;
 
 namespace RainbowBraces
 {
@@ -19,7 +20,7 @@ namespace RainbowBraces
 
         public char Close { get; }
 
-        public override bool TryAdd(string match, Span braceSpan, IReadOnlyList<(Span Span, TagAllowance Allowance)> matchingSpans, (string Line, int Offset) line)
+        public override bool TryAdd(string match, Span braceSpan, MatchingContext context, (string Line, int Offset) line)
         {
             if (match.Length != 1) return false;
             char c = match[0];
@@ -27,7 +28,7 @@ namespace RainbowBraces
             if (_allowedTags != null)
             {
                 // All matching tags must match allowed tags
-                if (matchingSpans.Any(t => !_allowedTags.Contains(t.Allowance))) return false;
+                if (context.MatchingSpans.Any(t => !_allowedTags.Contains(t.Allowance))) return false;
             }
 
             if (c == Open)

--- a/src/Tagger/BracePairBuilderCollection.cs
+++ b/src/Tagger/BracePairBuilderCollection.cs
@@ -22,6 +22,13 @@ namespace RainbowBraces
             _builders.Add(builder);
         }
 
+        public void AddBuilder<TBuilder>(Func<BracePairBuilderCollection, TBuilder> ctor)
+            where TBuilder : PairBuilder
+        {
+            TBuilder builder = ctor(this);
+            _builders.Add(builder);
+        }
+
         public void LoadFromCache(BracePairCache cache, int changeStart)
         {
             foreach (PairBuilder builder in _builders)

--- a/src/Tagger/CPlusPlusAllowanceResolver.cs
+++ b/src/Tagger/CPlusPlusAllowanceResolver.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.Language.StandardClassification;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 
@@ -13,57 +14,106 @@ namespace RainbowBraces.Tagger
         /// <remarks>The C++ tags are generated in second phase.</remarks>
         public override bool CanChangeTags => true;
 
-        /// <inheritdoc />
-        protected override TagAllowance IsAllowed(IClassificationType tagType)
+        private readonly Dictionary<(int Start, int End), string> _classificationByPosition = new ();
+
+        private static readonly HashSet<string> _allowedPreviousOpenClassifications;
+        private static readonly HashSet<string> _allowedPreviousCloseClassifications;
+        private static readonly HashSet<string> _allowedNextOpenClassifications;
+        private static readonly HashSet<string> _allowedClassifications;
+
+        static CPlusPlusAllowanceResolver()
         {
-            // TODO is part of "string", but string cannot be easily ignored.
-            //if (tagType.IsOfType("cppStringDelimiterCharacter")) return TagAllowance.Operator;
-            
-            return base.IsAllowed(tagType);
+            _allowedPreviousOpenClassifications = new()
+            {
+                "cppClassTemplate", // shared_ptr<...>
+                "cppFunction", // make_shared<...>()
+                "cppType", // enable_if_t<...>
+                "cppGlobalVariable", // is_convertible_t<...>
+                "cppLocalVariable", // x = variable<string>()
+                "keyword", // template <...>
+                "identifier" // <TFunc<...>>
+            };
+
+            _allowedPreviousCloseClassifications = new()
+            {
+                "cppType", // <TRet>
+                "keyword", // <bool>
+                "operator" // <TArgs...>
+            };
+
+            _allowedNextOpenClassifications = new()
+            {
+                "cppType", // <enable_if_t<...>>
+                "keyword", // <bool>
+                "identifier", // <invalid_token_but_preserve_brace_pairs>
+                "cppNamespace" // <std::string>
+            };
+
+            _allowedClassifications = _allowedPreviousOpenClassifications
+                .Concat(_allowedPreviousCloseClassifications)
+                .Concat(_allowedNextOpenClassifications)
+                .ToHashSet();
         }
 
-        /// <inheritdoc />
-        protected override TagAllowance IsAllowed(ILayeredClassificationType layeredType)
+        public override void Prepare()
         {
-            string classification = layeredType.Classification;
-            
-            // TODO is part of "string", but string cannot be easily ignored.
-            //if (classification == "cppStringDelimiterCharacter") return TagAllowance.Operator;
-
-            return base.IsAllowed(layeredType);
+            _classificationByPosition.Clear();
         }
 
-        /// <inheritdoc />
+        public override void Cleanup()
+        {
+            _classificationByPosition.Clear();
+        }
+
         protected override TagAllowance GetAllowance(IClassificationType tagType, IMappingSpan span)
         {
-            if (tagType.IsOfType(PredefinedClassificationTypeNames.Operator) && CanBeGenericParameterOperator(span))
+            // We'll remember important classifications.
+            if (_allowedClassifications.Contains(tagType.Classification))
             {
-                // Punctuation is used for generic arguments in C#, we'll use the same here.
-                return TagAllowance.Punctuation;
+                ITextBuffer buffer = span.AnchorBuffer;
+                foreach (SnapshotSpan snapshotSpan in span.GetSpans(buffer))
+                {
+                    (int, int) position = (snapshotSpan.Start.Position, snapshotSpan.End.Position);
+                    string classification = tagType.Classification;
+                    _classificationByPosition[position] = classification;
+                }
             }
 
             return base.GetAllowance(tagType, span);
         }
 
-        private static bool CanBeGenericParameterOperator(IMappingSpan span)
+        public string GetClassification(int start, int end)
         {
-            // Check id experimental flag is set.
-            if (!General.Instance.ExperimentalCPlusPlusGenerics) return false;
-
-            ITextBuffer buffer = span.AnchorBuffer;
-            NormalizedSnapshotSpanCollection textSpans = span.GetSpans(buffer);
-            if (textSpans.Count != 1) return false;
-
-            SnapshotSpan textSpan = textSpans[0];
-            if (textSpan.Length != 1) return false;
-
-            string text = textSpan.GetText();
-            return text switch
-            {
-                "<" => true,
-                ">" => true,
-                _ => false
-            };
+            _classificationByPosition.TryGetValue((start, end), out string classification);
+            return classification;
         }
+
+        /// <inheritdoc />
+        public override BracePairBuilderCollection CreateBuilders(General options)
+        {
+            // Create builders for each brace type only specific to C++
+            BracePairBuilderCollection builders = new();
+            if (options.Parentheses) builders.AddBuilder('(', ')');
+            if (options.CurlyBrackets) builders.AddBuilder('{', '}');
+            if (options.SquareBrackets) builders.AddBuilder('[', ']');
+            if (options.ExperimentalCPlusPlusGenerics) builders.AddBuilder(collection => new CPlusPlusTemplateTagPairBuilder(collection, this));
+
+            return builders;
+        }
+        
+        /// <summary>
+        /// Return <see langword="true"/> if classification is allowed to be before opening '&lt;' in C++ template.
+        /// </summary>
+        public static bool IsValidPreviousOpen(string classification) => _allowedPreviousOpenClassifications.Contains(classification);
+
+        /// <summary>
+        /// Return <see langword="true"/> if classification is allowed to be after opening '&lt;' in C++ template.
+        /// </summary>
+        public static bool IsValidPreviousClose(string classification) => _allowedPreviousCloseClassifications.Contains(classification);
+
+        /// <summary>
+        /// Return <see langword="true"/> if classification is allowed to be before closing '&gt;' in C++ template.
+        /// </summary>
+        public static bool IsValidNextOpen(string classification) => _allowedNextOpenClassifications.Contains(classification);
     }
 }

--- a/src/Tagger/CPlusPlusTemplateTagPairBuilder.cs
+++ b/src/Tagger/CPlusPlusTemplateTagPairBuilder.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Media.Animation;
+using System.Windows.Media;
+using Microsoft.VisualStudio.Text;
+using RainbowBraces.Tagger;
+
+namespace RainbowBraces;
+
+public class CPlusPlusTemplateTagPairBuilder : PairBuilder
+{
+    private readonly CPlusPlusAllowanceResolver _allowanceResolver;
+
+    public CPlusPlusTemplateTagPairBuilder(BracePairBuilderCollection collection, CPlusPlusAllowanceResolver allowanceResolver) : base(collection)
+    {
+        _allowanceResolver = allowanceResolver;
+    }
+
+    public override bool TryAdd(string match, Span braceSpan, MatchingContext context, (string Line, int Offset) line)
+    {
+        if (match is "<")
+        {
+            if (!BaseCheck(out MatchingContext.OrderedAllowanceSpan span)) return false;
+
+            if (!TryGetPrevious(span, out string previous)) return false;
+            if (!CPlusPlusAllowanceResolver.IsValidPreviousOpen(previous)) return false;
+
+            if (!TryGetNext(span, out string next)) return false;
+            if (!CPlusPlusAllowanceResolver.IsValidNextOpen(next)) return false;
+            
+            BracePair pair = new()
+            {
+                Level = NextLevel,
+                Open = braceSpan
+            };
+            Pairs.Add(pair);
+            OpenPairs.Push(pair);
+
+            return true;
+        }
+
+        if (match is ">")
+        {
+            if (!BaseCheck(out MatchingContext.OrderedAllowanceSpan span)) return false;
+
+            if (!TryGetPrevious(span, out string previous)) return false;
+            if (!CPlusPlusAllowanceResolver.IsValidPreviousClose(previous)) return false;
+
+            // We don't want to color errors in this case. (can be usual operator)
+            if (OpenPairs.Count == 0)
+            {
+                return false;
+            }
+
+            BracePair pair = OpenPairs.Pop();
+            pair.Close = braceSpan;
+            return true;
+        }
+        
+        return false;
+
+        bool BaseCheck(out MatchingContext.OrderedAllowanceSpan span)
+        {
+            span = null;
+            if (context.MatchingSpans.Count != 1) return false;
+
+            span = context.MatchingSpans[0];
+            return true;
+        }
+
+        bool TryGetPrevious(MatchingContext.OrderedAllowanceSpan span, out string previousClassification)
+        {
+            int previousIndex = span.FromStartOrderIndex - 1;
+            if (previousIndex < 0 || previousIndex >= context.FromStart.Count)
+            {
+                previousClassification = null;
+                return false;
+            }
+
+            MatchingContext.OrderedAllowanceSpan previous = context.FromStart[previousIndex];
+            previousClassification = _allowanceResolver.GetClassification(previous.Span.Start, previous.Span.End);
+            return true;
+        }
+
+        bool TryGetNext(MatchingContext.OrderedAllowanceSpan span, out string nextClassification)
+        {
+            int nextIndex = span.FromEndOrderIndex + 1;
+            if (nextIndex < 0 || nextIndex >= context.FromEnd.Count)
+            {
+                nextClassification = null;
+                return false;
+            }
+
+            MatchingContext.OrderedAllowanceSpan next = context.FromEnd[nextIndex];
+            nextClassification = _allowanceResolver.GetClassification(next.Span.Start, next.Span.End);
+            return true;
+        }
+    }
+}

--- a/src/Tagger/MatchingContext.cs
+++ b/src/Tagger/MatchingContext.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Text;
+
+namespace RainbowBraces.Tagger
+{
+    public class MatchingContext
+    {
+        public MatchingContext(IEnumerable<(SnapshotSpan Span, TagAllowance Allowance)> all)
+        {
+            All = all
+                .Select((tuple, i) => new AllowanceSpan(tuple.Span.Span, tuple.Allowance, i))
+                .ToArray();
+            
+            OrderedAllowanceSpan[] allOrdered = All
+                .Select(s => new OrderedAllowanceSpan(s))
+                .ToArray();
+
+            FromStart = allOrdered
+                .OrderBy(s => s.Span.Start)
+                .Select((s, i) =>
+                {
+                    s.FromStartOrderIndex = i;
+                    return s;
+                })
+                .ToArray();
+
+            FromEnd = allOrdered
+                .OrderBy(d => d.Span.End)
+                .Select((s, i) =>
+                {
+                    s.FromEndOrderIndex = i;
+                    return s;
+                })
+                .ToArray();
+        }
+
+        private IReadOnlyList<AllowanceSpan> All { get; }
+
+        public IReadOnlyList<OrderedAllowanceSpan> FromStart { get; }
+
+        public IReadOnlyList<OrderedAllowanceSpan> FromEnd { get; }
+
+        private int FromStartAdd { get; set; }
+
+        private int FromEndRemove { get; set; }
+
+        private Dictionary<int, OrderedAllowanceSpan> PossibleMatchingSpans { get; } = new();
+
+        public List<OrderedAllowanceSpan> MatchingSpans { get; } = new();
+
+        public void ProceedTo(int lineStart, int lineEnd)
+        {
+            // Remove all disallowed tags with end before this line
+            while (true)
+            {
+                if (FromEndRemove >= FromEnd.Count) break;
+                OrderedAllowanceSpan indexedSpan = FromEnd[FromEndRemove];
+                if (indexedSpan.Span.End >= lineStart) break;
+                PossibleMatchingSpans.Remove(indexedSpan.Index);
+                FromEndRemove++;
+            }
+
+            // Add all disallowed tags with start on this line
+            while (true)
+            {
+                if (FromStartAdd >= FromStart.Count) break;
+                OrderedAllowanceSpan indexedSpan = FromStart[FromStartAdd];
+                if (indexedSpan.Span.Start > lineEnd) break;
+                PossibleMatchingSpans.Add(indexedSpan.Index, indexedSpan);
+                FromStartAdd++;
+            }
+        }
+
+        public IReadOnlyList<OrderedAllowanceSpan> GetMatch(Match match, int position, int positionEnd)
+        {
+            // Enumeration of spans matching tags.
+            MatchingSpans.Clear();
+            MatchingSpans.AddRange(PossibleMatchingSpans.Values.Where(s => s.Span.Start <= position && s.Span.End > positionEnd));
+
+            // If match is more than 1 character, include possible smaller spans inside.
+            if (match.Length > 1)
+            {
+                MatchingSpans.AddRange(PossibleMatchingSpans.Values.Where(s => s.Span.Start >= position && s.Span.End <= positionEnd));
+            }
+
+            return MatchingSpans;
+        }
+
+        public record AllowanceSpan(Span Span, TagAllowance Allowance, int Index);
+
+        public class OrderedAllowanceSpan
+        {
+            public OrderedAllowanceSpan(AllowanceSpan allowanceSpan)
+            {
+                AllowanceSpan = allowanceSpan;
+            }
+
+            public AllowanceSpan AllowanceSpan { get; }
+
+            public int FromStartOrderIndex { get; set; }
+
+            public int FromEndOrderIndex { get; set; }
+
+            public Span Span => AllowanceSpan.Span;
+
+            public TagAllowance Allowance => AllowanceSpan.Allowance;
+
+            public int Index => AllowanceSpan.Index;
+        }
+    }
+}

--- a/src/Tagger/PairBuilder.cs
+++ b/src/Tagger/PairBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
+using RainbowBraces.Tagger;
 
 namespace RainbowBraces
 {
@@ -54,7 +55,7 @@ namespace RainbowBraces
             }
         }
 
-        public abstract bool TryAdd(string match, Span braceSpan, IReadOnlyList<(Span Span, TagAllowance Allowance)> matchingSpans, (string Line, int Offset) line);
+        public abstract bool TryAdd(string match, Span braceSpan, MatchingContext context, (string Line, int Offset) line);
 
         public virtual object GetCacheKey() => GetType();
 

--- a/src/Tagger/XmlTagPairBuilder.cs
+++ b/src/Tagger/XmlTagPairBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Text;
+using RainbowBraces.Tagger;
 
 namespace RainbowBraces
 {
@@ -17,12 +18,12 @@ namespace RainbowBraces
         }
 
         /// <inheritdoc />
-        public override bool TryAdd(string match, Span braceSpan, IReadOnlyList<(Span Span, TagAllowance Allowance)> matchingSpans, (string Line, int Offset) line)
+        public override bool TryAdd(string match, Span braceSpan, MatchingContext context, (string Line, int Offset) line)
         {
-            if (matchingSpans.Count == 0) return false;
+            if (context.MatchingSpans.Count == 0) return false;
             bool isOpenBracket = match is "<" or "</";
             bool isCloseBracket = match is ">" or "/>";
-            foreach ((Span Span, TagAllowance Allowance) matchingSpan in matchingSpans)
+            foreach (MatchingContext.OrderedAllowanceSpan matchingSpan in context.MatchingSpans)
             {
                 // Only XML tags are allowed to intersect
                 if (matchingSpan.Allowance != TagAllowance.XmlTag) return false;


### PR DESCRIPTION
Improved extensibility to allow look for surrounding of braces. 
- Wrapped running matching logic to class MatchingContext usable in PairBuilder
- Allowed AllowanceResolver to return builders specific only to his file.

Updated C++ template feature to guess whether '<' or '>' is part of template based on their surrounding.