### PR TITLE
Bug: Lost colorization on replace file content with the same code

### DIFF
--- a/src/Tagger/VerticalAdornmentsColorizer.cs
+++ b/src/Tagger/VerticalAdornmentsColorizer.cs
@@ -61,7 +61,7 @@ namespace RainbowBraces
 
         public bool Enabled { get; set; } = true;
 
-        public async Task ColorizeVerticalAdornmentsAsync(IReadOnlyCollection<ITextView> views, List<ITagSpan<IClassificationTag>> tags)
+        public async Task ColorizeVerticalAdornmentsAsync(IReadOnlyCollection<ITextView> views, IReadOnlyList<ITagSpan<IClassificationTag>> tags)
         {
             if (_failedReflection) return;
             ProcessTags(tags);
@@ -78,7 +78,7 @@ namespace RainbowBraces
             }
         }
 
-        private void ProcessTags(List<ITagSpan<IClassificationTag>> tags)
+        private void ProcessTags(IReadOnlyList<ITagSpan<IClassificationTag>> tags)
         {
             if (tags.Count == 0)
             {


### PR DESCRIPTION
Found another bug. When replacing file content with exactly same content, the colorization was lost because snapshot version was upgraded but all spans remained the same.

It happens often to me at work with extension that automatically reformat the file on save but not changes are made when the file was already formatted.