### PR TITLE
Minor fixes

### DIFF
--- a/src/Tagger/AllowanceResolver.cs
+++ b/src/Tagger/AllowanceResolver.cs
@@ -41,10 +41,17 @@ namespace RainbowBraces.Tagger
         {
             // Create builders for each brace type
             BracePairBuilderCollection builders = new();
+
             if (options.Parentheses) builders.AddBuilder('(', ')');
+
             if (options.CurlyBrackets) builders.AddBuilder('{', '}');
+
             if (options.SquareBrackets) builders.AddBuilder('[', ']');
-            if (options.AngleBrackets) builders.AddBuilder('<', '>', new[] { TagAllowance.Punctuation }); // Allow only punctuation
+
+            // Allow only punctuation.
+            // Ignore XML tags, in rare circumstances, Razor tagger will mark regular generics operator as XML tag, so we'll ignore it.
+            if (options.AngleBrackets) builders.AddBuilder('<', '>', Singleton.Punctuation, Singleton.XmlTag);
+
             if (options.XmlTags && AllowXmlTags) builders.AddXmlTagBuilder(AllowHtmlVoidElement);
 
             return builders;
@@ -107,5 +114,12 @@ namespace RainbowBraces.Tagger
         /// Implementation for allowance resolution for <see cref="ILayeredClassificationType"/>.
         /// </summary>
         protected abstract TagAllowance IsAllowed(ILayeredClassificationType layeredType);
+
+        private class Singleton
+        {
+            public static TagAllowance[] Punctuation { get; } = { TagAllowance.Punctuation };
+
+            public static TagAllowance[] XmlTag { get; } = { TagAllowance.XmlTag };
+        }
     }
 }

--- a/src/Tagger/BracePairBuilder.cs
+++ b/src/Tagger/BracePairBuilder.cs
@@ -8,12 +8,14 @@ namespace RainbowBraces
     public class BracePairBuilder : PairBuilder
     {
         private readonly TagAllowance[] _allowedTags;
+        private readonly TagAllowance[] _ignoredTags;
 
-        public BracePairBuilder(char open, char close, BracePairBuilderCollection collection, TagAllowance[] allowedTags) : base(collection)
+        public BracePairBuilder(char open, char close, BracePairBuilderCollection collection, TagAllowance[] allowedTags, TagAllowance[] ignoredTags) : base(collection)
         {
             Open = open;
             Close = close;
             _allowedTags = allowedTags;
+            _ignoredTags = ignoredTags;
         }
 
         public char Open { get; }
@@ -27,8 +29,16 @@ namespace RainbowBraces
 
             if (_allowedTags != null)
             {
+                IEnumerable<MatchingContext.OrderedAllowanceSpan> possibleSpans = context.MatchingSpans;
+
+                // Remove ignored tags
+                if (_ignoredTags is { Length: > 0 })
+                {
+                    possibleSpans = possibleSpans.Where(t => !_ignoredTags.Contains(t.Allowance));
+                }
+
                 // All matching tags must match allowed tags
-                if (context.MatchingSpans.Any(t => !_allowedTags.Contains(t.Allowance))) return false;
+                if (possibleSpans.Any(t => !_allowedTags.Contains(t.Allowance))) return false;
             }
 
             if (c == Open)

--- a/src/Tagger/BracePairBuilderCollection.cs
+++ b/src/Tagger/BracePairBuilderCollection.cs
@@ -10,9 +10,9 @@ namespace RainbowBraces
         
         public int Level => _builders.Sum(builder => builder.OpenPairs.Count);
 
-        public void AddBuilder(char open, char close, TagAllowance[] allowedTags = null)
+        public void AddBuilder(char open, char close, TagAllowance[] allowedTags = null, TagAllowance[] ignoredTags = null)
         {
-            BracePairBuilder builder = new(open, close, this, allowedTags);
+            BracePairBuilder builder = new(open, close, this, allowedTags, ignoredTags);
             _builders.Add(builder);
         }
 


### PR DESCRIPTION
Fix not colorized C# generics in Razor code section in rare circumstances.
![image](https://github.com/madskristensen/RainbowBraces/assets/17590847/9828bdf3-2da0-4465-8b00-427ae6781bec)

Tries to fix wrong colorization after quick edits. For a few milliseconds the colorized tags are shifted. It is hard to simulate reliably.