### PR TITLE
Minor fix

### DIFF
--- a/src/Tagger/DefaultAllowanceResolver.cs
+++ b/src/Tagger/DefaultAllowanceResolver.cs
@@ -13,6 +13,7 @@ namespace RainbowBraces.Tagger
             if (tagType.IsOfType(PredefinedClassificationTypeNames.Operator)) return TagAllowance.Operator;
             if (tagType.IsOfType("XAML Delimiter")) return TagAllowance.Delimiter;
             if (tagType.IsOfType("SQL Operator")) return TagAllowance.Operator;
+            if (tagType.IsOfType("unnecessary code")) return TagAllowance.Ignore;
             return TagAllowance.Disallowed;
         }
 
@@ -28,6 +29,7 @@ namespace RainbowBraces.Tagger
                 PredefinedClassificationTypeNames.Operator => TagAllowance.Operator,
                 "XAML Delimiter" => TagAllowance.Delimiter,
                 "SQL Operator" => TagAllowance.Operator,
+                "unnecessary code" => TagAllowance.Ignore,
                 _ => TagAllowance.Disallowed,
             };
             if (allowance != TagAllowance.Disallowed) return allowance;

--- a/src/Tagger/RainbowTagger.cs
+++ b/src/Tagger/RainbowTagger.cs
@@ -357,7 +357,10 @@ namespace RainbowBraces
             // Add tags to instantiated list to reduce allocations on UI thread and increase responsiveness
             // We expect tags count not to differ a lot between invocations so memory should not be wasted a lot
             _tempTagList.Clear();
-            _tempTagList.AddRange(_aggregator.GetTags(wholeDocSpan));
+            _tempTagList.AddRange(_aggregator.GetTags(wholeDocSpan)
+                // Ignore our own tags if they get into the list.
+                .Where(t => !t.Tag.ClassificationType.Classification.StartsWith("Rainbow Brace level "))
+            );
 
             // Move the rest of the execution to a background thread.
             await TaskScheduler.Default;

--- a/src/Tagger/RainbowTagger.cs
+++ b/src/Tagger/RainbowTagger.cs
@@ -165,7 +165,7 @@ namespace RainbowBraces
                 _specializedRegex = null;
                 _scanWholeFile = false;
                 int visibleStart = GetVisibleStart();
-                int visibleEnd = GetVisibleEnd();
+                int visibleEnd = GetVisibleEnd(_buffer.CurrentSnapshot);
                 TagsChanged?.Invoke(this, new(new(_buffer.CurrentSnapshot, visibleStart, visibleEnd - visibleStart)));
             }
 
@@ -348,7 +348,7 @@ namespace RainbowBraces
             }
 
             int visibleStart = GetVisibleStart();
-            int visibleEnd = GetVisibleEnd();
+            int visibleEnd = GetVisibleEnd(currentSnapshot);
             ITextSnapshotLine changedLine = currentSnapshot.GetLineFromPosition(topPosition);
             int changeStart = changedLine.Start.Position;
 
@@ -366,7 +366,7 @@ namespace RainbowBraces
             await TaskScheduler.Default;
 
             // Check if tags are equal from last processing.
-            if (AreEqualTags(_tagList, _tempTagList))
+            if (AreEqualTags(_tagList, _tempTagList, currentSnapshot))
             {
                 // We can clear the temporary list to avoid memory leaks.
                 _tempTagList.Clear();
@@ -394,7 +394,7 @@ namespace RainbowBraces
             _spanList.AddRange(_tagList
                 .Select(tag => (Tag: tag, Allowance: _allowanceResolver.GetAllowance(tag)))
                 .Where(d => d.Allowance != TagAllowance.Ignore)
-                .SelectMany(d => d.Tag.Span.GetSpans(_buffer).Where(s => !s.IsEmpty).Select(span => (span, d.Allowance))));
+                .SelectMany(d => d.Tag.Span.GetSpans(currentSnapshot).Where(s => !s.IsEmpty).Select(span => (span, d.Allowance))));
             IList<(SnapshotSpan Span, TagAllowance Allowance)> allDisallow = _spanList;
 
             // Create builders for file.
@@ -478,7 +478,7 @@ namespace RainbowBraces
             // Processing has ended.
             _allowanceResolver.Cleanup();
 
-            IReadOnlyList<ITagSpan<IClassificationTag>> tags = GenerateTagSpans(builders.SelectMany(b => b.GetPairs()), options.CycleLength);
+            IReadOnlyList<ITagSpan<IClassificationTag>> tags = GenerateTagSpans(builders.SelectMany(b => b.GetPairs()), options.CycleLength, currentSnapshot);
 
             // Check if tag collection is different from previous result. If so, we do not need to raise TagsChanged event.
             if (AreEqualTags(tags, _tags)) return;
@@ -489,7 +489,7 @@ namespace RainbowBraces
             if (options.VerticalAdornments) ColorizeVerticalAdornments();
         }
 
-        private bool AreEqualTags(IReadOnlyList<IMappingTagSpan<IClassificationTag>> originalTags, IReadOnlyList<IMappingTagSpan<IClassificationTag>> newTags)
+        private static bool AreEqualTags(IReadOnlyList<IMappingTagSpan<IClassificationTag>> originalTags, IReadOnlyList<IMappingTagSpan<IClassificationTag>> newTags, ITextSnapshot snapshot)
         {
             if (originalTags.Count != newTags.Count) return false;
             for (int i = 0; i < originalTags.Count; i++)
@@ -497,7 +497,7 @@ namespace RainbowBraces
                 IMappingTagSpan<IClassificationTag> originalTag = originalTags[i];
                 IMappingTagSpan<IClassificationTag> newTag = newTags[i];
                 if (!originalTag.Tag.ClassificationType.Classification.Equals(newTag.Tag.ClassificationType.Classification)) return false;
-                if (!AreEqualSpans(originalTag.Span.GetSpans(_buffer), newTag.Span.GetSpans(_buffer))) return false;
+                if (!AreEqualSpans(originalTag.Span.GetSpans(snapshot), newTag.Span.GetSpans(snapshot))) return false;
             }
             return true;
         }
@@ -538,7 +538,7 @@ namespace RainbowBraces
             }
         }
 
-        private IReadOnlyList<ITagSpan<IClassificationTag>> GenerateTagSpans(IEnumerable<BracePair> pairs, int cycleLength)
+        private IReadOnlyList<ITagSpan<IClassificationTag>> GenerateTagSpans(IEnumerable<BracePair> pairs, int cycleLength, ITextSnapshot snapshot)
         {
             List<ITagSpan<IClassificationTag>> tags = new();
 
@@ -546,11 +546,11 @@ namespace RainbowBraces
             {
                 IClassificationType classification = _registry.GetClassificationType(ClassificationTypes.GetName(pair.Level, cycleLength));
                 ClassificationTag openTag = new(classification);
-                SnapshotSpan openSpan = new(_buffer.CurrentSnapshot, pair.Open);
+                SnapshotSpan openSpan = new(snapshot, pair.Open);
                 tags.Add(new TagSpan<IClassificationTag>(openSpan, openTag));
 
                 ClassificationTag closeTag = new(classification);
-                SnapshotSpan closeSpan = new(_buffer.CurrentSnapshot, pair.Close);
+                SnapshotSpan closeSpan = new(snapshot, pair.Close);
                 tags.Add(new TagSpan<IClassificationTag>(closeSpan, closeTag));
             }
 
@@ -565,11 +565,11 @@ namespace RainbowBraces
             return visibleStart;
         }
 
-        private int GetVisibleEnd()
+        private int GetVisibleEnd(ITextSnapshot snapshot)
         {
-            if (_scanWholeFile) return _buffer.CurrentSnapshot.Length;
+            if (_scanWholeFile) return snapshot.Length;
 
-            int visibleEnd = Math.Min(_views.Max(view => view.TextViewLines.Last().End.Position) + _overflow, _buffer.CurrentSnapshot.Length);
+            int visibleEnd = Math.Min(_views.Max(view => view.TextViewLines.Last().End.Position) + _overflow, snapshot.Length);
             return visibleEnd;
         }
 


### PR DESCRIPTION
Fixes:
- When some code was marked as unreachable, the braces were not colorized. After the code was reachable again, colorization could be off anyway when was above change.
- Sometimes happened (usually after long typing in big files) that braces were flashing after every edit made. Different braces were colorized differently on/off. It was caused by own Rainbow Brace tags. I dont know how it could happen or how it could not happened before. Is it possible to be introduced by change that `ITagAggregator` is recreated after view it was attached on was closed?

Also I've tried to minimize possible conflicts with `ITextSnapshot`. I'm not sure but it looked to me that it was possible for snapshot to be upgraded during and some functions used the old one and some the newest. Now they should all use consistently the old one and the new one could be used in another run if found incompatible.