### PR TITLE
Fix: Vertical lines don't show up in Preview version of Visual Studio

### DIFF
--- a/src/RainbowBraces.csproj
+++ b/src/RainbowBraces.csproj
@@ -108,6 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Design" />
     <Reference Include="System.ComponentModel.Composition" />


### PR DESCRIPTION
In current preview version of Visual Studio has changed how adornments are rendered. I had to update the reflection path to properly recolor them (the old versions should be intact).

The new adornments rendering looks promising because they weren't flashing and maybe can be set once and not multiple times on every scroll event. Will check and maybe vertical lines could then be on by default.