### PR TITLE
Fix rainbow colors with C# code background in Razor files enabled

### DIFF
--- a/src/Tagger/RazorAllowanceResolver.cs
+++ b/src/Tagger/RazorAllowanceResolver.cs
@@ -29,6 +29,9 @@ public class RazorAllowanceResolver : DefaultAllowanceResolver
         // string (eg. interpolated or parameter filling) tag can contain punctuation or inlined C# code and braces without tags are ignored by default (DefaultAllowed = false)
         if (tagType.IsOfType(PredefinedClassificationTypeNames.String)) return TagAllowance.Ignore;
 
+        // ignore razor code background highlighting
+        if (tagType.IsOfType("RazorCode")) return TagAllowance.Ignore;
+
         if (General.Instance.XmlTags)
         {
             if (tagType.IsOfType("HTML Tag Delimiter")) return TagAllowance.XmlTag;
@@ -45,6 +48,9 @@ public class RazorAllowanceResolver : DefaultAllowanceResolver
 
         // string (eg. interpolated or parameter filling) tag can contain punctuation or inlined C# code and braces without tags are ignored by default (DefaultAllowed = false)
         if (classification == PredefinedClassificationTypeNames.String) return TagAllowance.Ignore;
+
+        // ignore razor code background highlighting
+        if (classification == "RazorCode") return TagAllowance.Ignore;
 
         if (General.Instance.XmlTags)
         {


### PR DESCRIPTION
Brace colorization don't work when this checkbox is checked.

<img width="325" height="56" alt="image" src="https://github.com/user-attachments/assets/8a608d56-10bb-4416-a2b5-f51a261bf4d9" />
